### PR TITLE
Better Google Maps directions handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,41 +155,41 @@
     });
 
     function directions(to) {
-      var from = getFrom();
-      if (from == null) {
-        var r = confirm("Location settings are off. Turn on?");
-        if (r == true) {
-          toLoc = to;
-          map.on('locationfound', updateLocationForDirections);
-          map.locate();
-          return;
-        } else {
-          return;
-        }
-      }
-
-      window.location.href = "comgooglemapsurl://maps.google.com/?saddr=" + from + "&daddr=" + to;
+      // var from = getFrom();
+      // if (from == null) {
+      //   var r = confirm("Location settings are off. Turn on?");
+      //   if (r == true) {
+      //     toLoc = to;
+      //     map.on('locationfound', updateLocationForDirections);
+      //     map.locate();
+      //     return;
+      //   } else {
+      //     return;
+      //   }
+      // }
+      // NOTE: Removing ---> ?saddr=" + from +  from URL
+      window.location.href = "comgooglemapsurl://maps.google.com/&daddr=" + to + "&directionsmode=driving";
     }
 
-    function getFrom() {
-      if (myLoc != null) {
-        return myLoc.latitude + "," + myLoc.longitude;
-      } else {
-        return null;
-      }
-    }
+    // function getFrom() {
+    //   if (myLoc != null) {
+    //     return myLoc.latitude + "," + myLoc.longitude;
+    //   } else {
+    //     return null;
+    //   }
+    // }
 
-    function updateLocation(e) {
-      myLoc = e;
-    }
-
-    function updateLocationForDirections(e) {
-      myLoc = e;
-      directions(toLoc);
-      map.on('locationfound', updateLocation);
-    }
-
-    map.on('locationfound', updateLocation);
+    // function updateLocation(e) {
+    //   myLoc = e;
+    // }
+    //
+    // function updateLocationForDirections(e) {
+    //   myLoc = e;
+    //   directions(toLoc);
+    //   map.on('locationfound', updateLocation);
+    // }
+    //
+    // map.on('locationfound', updateLocation);
 
 	jQuery("#searchfield").on('keyup', function(){
 		var searchString = $('#searchfield').val().toLowerCase();

--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
       //   }
       // }
       // NOTE: Removing ---> ?saddr=" + from +  from URL
-      window.location.href = "https://maps.google.com/&daddr=" + to + "&directionsmode=driving";
+      window.location.href = "https://maps.google.com/?daddr=" + to;
     }
 
     // function getFrom() {

--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
         }
       }
 
-      window.location.href = "https://maps.google.com/?saddr=" + from + "&daddr=" + to;
+      window.location.href = "comgooglemapsurl://maps.google.com/?saddr=" + from + "&daddr=" + to;
     }
 
     function getFrom() {

--- a/index.html
+++ b/index.html
@@ -159,7 +159,7 @@
       // if (from == null) {
       //   var r = confirm("Location settings are off. Turn on?");
       //   if (r == true) {
-      //     toLoc = to;
+          toLoc = to;
       //     map.on('locationfound', updateLocationForDirections);
       //     map.locate();
       //     return;
@@ -168,7 +168,7 @@
       //   }
       // }
       // NOTE: Removing ---> ?saddr=" + from +  from URL
-      window.location.href = "comgooglemapsurl://maps.google.com/&daddr=" + to + "&directionsmode=driving";
+      window.location.href = "https://maps.google.com/&daddr=" + to + "&directionsmode=driving";
     }
 
     // function getFrom() {


### PR DESCRIPTION
This PR would remove the entire `from` protocol from the site, allowing the user to get directions without specifying a from address. Absent a `?saddr` (start address, see #56), the map just assumes the users current location.